### PR TITLE
Update MCS references to new mcs-cli org

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ Additional providers available via the AI module: AWS Bedrock, Azure OpenAI, Hug
 
 ### Claude Code Configuration & Orchestration
 
-- [bguidolim/managed-claude-stack (MCS)](https://github.com/bguidolim/mcs) (★ 65) — Config engine for Claude Code; shareable "tech packs" bundle MCP servers, plugins, hooks, skills, commands; convergence sync, drift detection, lockfiles; `brew install bguidolim/tap/managed-claude-stack` ★★★★
+- [mcs-cli/mcs (MCS)](https://mcs-cli.dev) (★ 84) — Config engine for Claude Code; shareable "tech packs" bundle MCP servers, plugins, hooks, skills, commands, agents; convergence sync, drift detection, lockfiles; `brew install mcs-cli/tap/mcs` ★★★★
 - [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode) (★ 10,100+) — Multi-agent orchestration for Claude Code; 32 agents; Ralph/Autopilot/Ultrawork modes; smart model routing; 30-50% token savings ★★★★
 - [ngxtm/devkit](https://github.com/ngxtm/devkit) — 414+ skills, 38 agents, 57 commands; multi-tool (Claude, Cursor, Copilot, Gemini); smart tech detection; no Drupal skills yet ★★★
 

--- a/research/11-alternative-ai-tools-starterkit.md
+++ b/research/11-alternative-ai-tools-starterkit.md
@@ -225,10 +225,10 @@ Drupal lacks unified AI-assisted development approach. Current ecosystem is "fra
 
 ## Managed Claude Stack (MCS) — Configuration Engine for Claude Code
 
-- **URL:** https://github.com/bguidolim/mcs
-- **Stars:** 65 | **Forks:** 4 | **License:** MIT
+- **URL:** https://github.com/mcs-cli/mcs | **Website:** https://mcs-cli.dev
+- **Stars:** 84 | **Forks:** 7 | **License:** MIT
 - **Language:** Swift (macOS 13+)
-- **Install:** `brew install bguidolim/tap/managed-claude-stack`
+- **Install:** `brew install mcs-cli/tap/mcs`
 - **Description:** Configuration engine for Claude Code that packages development environments into shareable "tech packs." Tech packs are Git-based repos with `techpack.yaml` manifests bundling MCP servers, plugins, hooks, skills, commands, and settings.
 
 ### Key Features
@@ -246,9 +246,11 @@ mcs doctor                  # Verify setup
 ```
 
 ### Example Packs
-- `mcs-core-pack` — Foundational Claude Code settings
-- `mcs-continuous-learning` — Persistent memory across sessions
-- `mcs-ios-pack` — Xcode/Swift integration
+- `mcs-cli/dev` — Foundational Claude Code settings
+- `mcs-cli/memory` — Persistent memory across sessions
+- `mcs-cli/ios` — Xcode/Swift integration
+
+Browse all packs at [techpacks.mcs-cli.dev](https://techpacks.mcs-cli.dev)
 
 ### Drupal Relevance
 - **Not Drupal-specific yet**, but a Drupal/DDEV tech pack could bundle all Drupal skills, MCP servers, and DDEV integrations into one installable pack


### PR DESCRIPTION
## Summary
- MCS (Managed Claude Stack) has moved from `bguidolim/mcs` to `mcs-cli/mcs` and now has a dedicated website at [mcs-cli.dev](https://mcs-cli.dev)
- Updated all references in README.md and research file to reflect the new org, URL, brew tap, stats, and renamed tech packs
- Added link to the new tech pack browser at [techpacks.mcs-cli.dev](https://techpacks.mcs-cli.dev)

## Test plan
- [ ] Verify all links in README.md resolve correctly
- [ ] Verify all links in `research/11-alternative-ai-tools-starterkit.md` resolve correctly
- [ ] Confirm no stale `bguidolim/mcs` or `bguidolim/tap` references remain